### PR TITLE
MemoryTracker cuda::memcpy_async support

### DIFF
--- a/MemoryTracker/MemoryTracker.cpp
+++ b/MemoryTracker/MemoryTracker.cpp
@@ -81,6 +81,7 @@ void ModuleLoaded(Sanitizer_ResourceModuleData* pModuleData)
     sanitizerPatchInstructions(SANITIZER_INSTRUCTION_GLOBAL_MEMORY_ACCESS, pModuleData->module, "MemoryGlobalAccessCallback");
     sanitizerPatchInstructions(SANITIZER_INSTRUCTION_SHARED_MEMORY_ACCESS, pModuleData->module, "MemorySharedAccessCallback");
     sanitizerPatchInstructions(SANITIZER_INSTRUCTION_LOCAL_MEMORY_ACCESS, pModuleData->module, "MemoryLocalAccessCallback");
+    sanitizerPatchInstructions(SANITIZER_INSTRUCTION_MEMCPY_ASYNC, pModuleData->module, "MemcpyAsyncCallback");
     sanitizerPatchModule(pModuleData->module);
 }
 

--- a/MemoryTracker/MemoryTrackerPatches.cu
+++ b/MemoryTracker/MemoryTrackerPatches.cu
@@ -88,3 +88,14 @@ SanitizerPatchResult MemoryLocalAccessCallback(
 {
     return CommonCallback(userdata, pc, ptr, accessSize, flags, MemoryAccessType::Local);
 }
+
+extern "C" __device__ __noinline__
+SanitizerPatchResult MemcpyAsyncCallback(void* userdata, uint64_t pc, void* src, uint32_t dst, uint32_t accessSize, uint32_t totalShmemSize)
+{
+    if (src)
+    {
+        CommonCallback(userdata, pc, src, accessSize, SANITIZER_MEMORY_DEVICE_FLAG_READ, MemoryAccessType::Global);
+    }
+
+    return CommonCallback(userdata, pc, (void*)dst, accessSize, SANITIZER_MEMORY_DEVICE_FLAG_WRITE, MemoryAccessType::Shared);
+}


### PR DESCRIPTION
Tracker now reports reads and writes resulting from a cuda::memcpy_async operation.